### PR TITLE
fix: enable become-a-member button for disconnected wallet

### DIFF
--- a/containers/PageProjectDetails/containers/PanelBenefits/containers/TierViewer/containers/Tier/index.tsx
+++ b/containers/PageProjectDetails/containers/PanelBenefits/containers/TierViewer/containers/Tier/index.tsx
@@ -150,14 +150,15 @@ export default function Tier({
                     )
               }
               disabled={
-                (value.maximumMembers != null &&
+                walletStatus.status !== "disconnected" &&
+                ((value.maximumMembers != null &&
                   (value.activeMemberCount || 0) >= value.maximumMembers &&
                   currentTier?.id !== value.id) ||
-                value.requiredStake >
-                  sumLovelaceAmount([
-                    actualStakingAmount,
-                    maxLovelaceAmount ?? 0,
-                  ])
+                  value.requiredStake >
+                    sumLovelaceAmount([
+                      actualStakingAmount,
+                      maxLovelaceAmount ?? 0,
+                    ]))
               }
             />
           )}


### PR DESCRIPTION
This is ugly and not enough. We want to show the backing modal after connecting the wallet, not asking the user to click the become-a-member button again.